### PR TITLE
Allow for regex match of INTEGER types in json

### DIFF
--- a/behave_web_api/utils.py
+++ b/behave_web_api/utils.py
@@ -84,10 +84,11 @@ def compare_values(expected_value, actual_value, path=None):
         compare_dicts(expected_value, actual_value, path=path)
     elif type(expected_value) is list:
         compare_lists(expected_value, actual_value, path=path)
-    elif isinstance(expected_value, string_type)\
-            and expected_value[0] == '%'\
-            and expected_value[-1] == '%':
-        if not re.match(expected_value.strip('%'), actual_value or ''):
+    elif isinstance(expected_value, string_type) \
+            and (expected_value[0] == '%' or expected_value.startswith('INT%')) and expected_value[-1] == '%':
+        if expected_value.startswith('INT%') and \
+            not re.match(expected_value.strip('INT').strip('%'), str(actual_value) or '') or \
+            isinstance(actual_value, string_type) and not re.match(expected_value.strip('%'), actual_value or ''):
             message = 'Expected {0} to match regex {1}'
             params = [repr(actual_value), repr(expected_value)]
 


### PR DESCRIPTION
Prior to this, the JSON like this would fail:

"""
{u'client_id': 1,
u'description': u'Non corrupti ab amet hic quis.',
u'geometries': [{u'height': 999,
                         u'parent': {u'atom_id': 3,
                                         u'id': 3,
                                         u'owner': {u'client_id': 1,
                                                         u'group_id': 9,
                                                         u'id': 9,
                                                         u'type': 2,
                                                         u'user_id': 19},
                                         u'type': 1},
                         u'uuid': u'7ffe01ae96bd42fb8695fd41dee95504',
                         u'width': 742}],
u'name': u'redefine holistic supply-chains'}
"""

"""
{
"client_id": 1,
"description": "%[a-zA-Z0-9]*%",
"geometries": [
    {
    "height": <HOW TO MATCH REGEX ON INTs?>,
    "width": <HOW TO MATCH REGEX ON INTs?>,
    "parent": {},
    "uuid": "%[a-zA-Z0-9]+%"
    }
    ]
}
"""

But now, we can do the following:

"""
{
"client_id": 1,
"description": "%[a-zA-Z0-9]*%",
"geometries": [
    {
    "height": "INT%[0-9]+%",
    "width": "INT%[0-9]+%",
    "parent": {},
    "uuid": "%[a-zA-Z0-9]+%"
    }
    ]
}
"""

Which will match the integers