### PR TITLE
fix: declare classifiers in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,17 @@ dependencies = [
     "behave>=1.2.6,<2.0.0",
     "requests>=2.31.0",
 ]
+classifiers = [
+    "Operating System :: OS Independent",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Web Environment",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Testing",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 
 [project.optional-dependencies]
 test = [

--- a/setup.py
+++ b/setup.py
@@ -27,15 +27,4 @@ setup(
     author='Jeferson Daniel',
     author_email='jeferson.daniel412@gmail.com',
     license='MIT',
-    classifiers=[
-        'Operating System :: OS Independent',
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Web Environment',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Topic :: Software Development :: Testing',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-    ]
 )


### PR DESCRIPTION
## Summary
- move package classifiers into pyproject for setuptools compliance
- drop redundant classifier list from setup.py

## Testing
- `uv sync --all-extras`
- `uv run ./runtests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c0ddf13bc083208a4a1e4698a87a94