### PR TITLE
fix: fix JSON assertion path reporting in checker

### DIFF
--- a/behave_web_api/utils.py
+++ b/behave_web_api/utils.py
@@ -53,12 +53,12 @@ def compare_lists(expected_list, actual_list, path=None):
         "Actual {0} is not a list".format(repr(actual_list))
 
     for i, item in enumerate(expected_list):
-        path = '{0}.{1}'.format(path, i) if path else str(i)
+        current_path = '{0}.{1}'.format(path, i) if path else str(i)
         try:
             actual_value = actual_list[i]
         except ValueError:
             actual_value = None
-        compare_values(item, actual_value, path=path)
+        compare_values(item, actual_value, path=current_path)
 
 
 def compare_dicts(expected_dict, actual_dict, path=None):
@@ -70,9 +70,9 @@ def compare_dicts(expected_dict, actual_dict, path=None):
     for key in expected_dict:
         expected_value = expected_dict[key]
         actual_value = actual_dict.get(key, None)
-        path = '{0}.{1}'.format(path, key) if path else key
+        current_path = '{0}.{1}'.format(path, key) if path else key
 
-        compare_values(expected_value, actual_value, path=path)
+        compare_values(expected_value, actual_value, path=current_path)
 
 
 def validate_value(validator, value):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -125,3 +125,91 @@ class UtilsTest(unittest.TestCase):
             'Expected response to contain text \'my name is not\'',
             error.args[0]
         )
+
+    def test_path_for_multiple_list_items(self):
+        """Test that path is correctly computed for multiple items in a list"""
+        error = None
+
+        try:
+            utils.compare_values(
+                [1, 2, 3],
+                [1, 2, 999]
+            )
+        except AssertionError as e:
+            error = e
+
+        # The error should be at index 2, not some accumulated path
+        self.assertEqual(
+            'Expected 999 to equal 3 at path 2',
+            error.args[0]
+        )
+
+    def test_path_for_multiple_dict_keys(self):
+        """Test that path is correctly computed for multiple keys in a dict"""
+        errors = []
+
+        # Test first key
+        try:
+            utils.compare_values(
+                {'a': 1, 'b': 2, 'c': 3},
+                {'a': 999, 'b': 2, 'c': 3}
+            )
+        except AssertionError as e:
+            errors.append(e.args[0])
+
+        # Test second key
+        try:
+            utils.compare_values(
+                {'a': 1, 'b': 2, 'c': 3},
+                {'a': 1, 'b': 999, 'c': 3}
+            )
+        except AssertionError as e:
+            errors.append(e.args[0])
+
+        # Test third key
+        try:
+            utils.compare_values(
+                {'a': 1, 'b': 2, 'c': 3},
+                {'a': 1, 'b': 2, 'c': 999}
+            )
+        except AssertionError as e:
+            errors.append(e.args[0])
+
+        self.assertEqual('Expected 999 to equal 1 at path a', errors[0])
+        self.assertEqual('Expected 999 to equal 2 at path b', errors[1])
+        self.assertEqual('Expected 999 to equal 3 at path c', errors[2])
+
+    def test_path_for_nested_list_with_multiple_errors(self):
+        """Test that path is correctly computed in nested structures"""
+        error = None
+
+        try:
+            utils.compare_values(
+                {'items': [{'id': 1}, {'id': 2}, {'id': 3}]},
+                {'items': [{'id': 1}, {'id': 2}, {'id': 999}]}
+            )
+        except AssertionError as e:
+            error = e
+
+        # Should be items.2.id, not something like items.0.1.2.id
+        self.assertEqual(
+            'Expected 999 to equal 3 at path items.2.id',
+            error.args[0]
+        )
+
+    def test_path_for_list_in_nested_dict(self):
+        """Test path computation for lists inside nested dicts"""
+        error = None
+
+        try:
+            utils.compare_values(
+                {'data': {'users': ['alice', 'bob', 'charlie']}},
+                {'data': {'users': ['alice', 'bob', 'eve']}}
+            )
+        except AssertionError as e:
+            error = e
+
+        self.assertEqual(
+            'Expected \'eve\' to equal \'charlie\' at path data.users.2',
+            error.args[0]
+        )


### PR DESCRIPTION
Fixed a bug where the path variable was being reused and accumulated incorrectly in compare_lists() and compare_dicts() functions. This caused paths like "0.1.2" instead of "2" and "a.b" instead of "b".

Changes:
- Renamed loop-local path variable to current_path in compare_lists()
- Renamed loop-local path variable to current_path in compare_dicts()
- Added 4 comprehensive unit tests to verify correct path computation:
  - test_path_for_multiple_list_items
  - test_path_for_multiple_dict_keys
  - test_path_for_nested_list_with_multiple_errors
  - test_path_for_list_in_nested_dict

The fix ensures that JSON assertion error messages now correctly report the path where mismatches occur.